### PR TITLE
Add evil compatibility Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This is mostly pod management for now. More may come.
 
 Get it from Melpa, or copy and load the `kubel.el` file.
 
+If you want to have the evil compatibility package, get it from Melpa as well or
+load the `kubel-evil.el` file.
+
 ## Usage
 
 To list the pods in your current context and namespace, call

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -35,7 +35,7 @@
 ;; On the kubel screen, place your cursor on the pod
 ;;
 ;; enter => get pod details
-;; ? => help popup
+;; h => help popup
 ;; C => set context
 ;; n => set namespace
 ;; g => refresh pods
@@ -52,6 +52,21 @@
 (require 'evil)
 (require 'kubel)
 
+(define-transient-command kubel-evil-help-popup ()
+  "Kubel Evil Menu"
+  ["Actions"
+   ("ENTER" "Pod details" kubel-get-pod-details)
+   ("C" "Set Context" kubel-set-context)
+   ("n" "Set namespace" kubel-set-namespace)
+   ("g" "Refresh" kubel-mode)
+   ("p" "Port forward" kubel-port-forward-pod)
+   ("l" "Logs" kubel-log-popup)
+   ("c" "Copy" kubel-copy-popup)
+   ("o" "Describe" kubel-describe-popup)
+   ("e" "Exec" kubel-exec-pod)
+   ("d" "Delete" kubel-delete-popup)
+   ("a" "Jab" kubel-jab-deployment)])
+
 (evil-set-initial-state 'kubel-mode 'motion)
 (evil-define-key 'motion kubel-mode-map
   (kbd "RET") #'kubel-get-pod-details
@@ -61,7 +76,7 @@
   (kbd "p") #'kubel-port-forward-pod
   (kbd "l") #'kubel-log-popup
   (kbd "c") #'kubel-copy-popup
-  (kbd "?") #'kubel-help-popup
+  (kbd "h") #'kubel-evil-help-popup
   (kbd "o") #'kubel-describe-popup
   (kbd "e") #'kubel-exec-pod
   (kbd "d") #'kubel-delete-popup

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -1,0 +1,70 @@
+;;; kubel-evil.el --- extension for kubel to provide evil keybindings
+
+;; Copyright (C) 2019, Marcel Patzwahl
+
+;; This file is NOT part of Emacs.
+
+;; This  program is  free  software; you  can  redistribute it  and/or
+;; modify it  under the  terms of  the GNU  General Public  License as
+;; published by the Free Software  Foundation; either version 2 of the
+;; License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT  ANY  WARRANTY;  without   even  the  implied  warranty  of
+;; MERCHANTABILITY or FITNESS  FOR A PARTICULAR PURPOSE.   See the GNU
+;; General Public License for more details.
+
+;; You should have  received a copy of the GNU  General Public License
+;; along  with  this program;  if  not,  write  to the  Free  Software
+;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+;; USA
+
+;; Version: 1.0
+;; Author: Marcel Patzwahl
+;; Keywords: kubernetes k8s tools processes evil keybindings
+;; URL: https://github.com/abrochard/kubel
+;; License: GNU General Public License >= 3
+;; Package-Requires: ((kubel "1.0") (evil "1.0"))
+
+;;; Commentary:
+
+;; Emacs extension for controlling Kubel with evil keybindings.
+
+;;; Shortcuts:
+
+;; On the kubel screen, place your cursor on the pod
+;;
+;; enter => get pod details
+;; ? => help popup
+;; C => set context
+;; n => set namespace
+;; g => refresh pods
+;; p => port forward pod
+;; e => exec into pod
+;; o => describe popup
+;; l => log popup
+;; c => copy popup
+;; d => delete pod
+;; a => jab deployment to force rolling update
+;;
+
+;;; Customize:
+(require 'evil)
+(require 'kubel)
+
+(evil-set-initial-state 'kubel-mode 'motion)
+(evil-define-key 'motion kubel-mode-map
+  (kbd "RET") 'kubel-get-pod-details
+  (kbd "C") 'kubel-set-context
+  (kbd "n") 'kubel-set-namespace
+  (kbd "g") 'kubel-mode
+  (kbd "p") 'kubel-port-forward-pod
+  (kbd "l") 'kubel-log-popup
+  (kbd "c") 'kubel-copy-popup
+  (kbd "?") 'kubel-help-popup
+  (kbd "o") 'kubel-describe-popup
+  (kbd "e") 'kubel-exec-pod
+  (kbd "d") 'kubel-delete-popup
+  (kbd "a") 'kubel-jab-deployment)
+
+(provide 'kubel-evil)

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -54,17 +54,17 @@
 
 (evil-set-initial-state 'kubel-mode 'motion)
 (evil-define-key 'motion kubel-mode-map
-  (kbd "RET") 'kubel-get-pod-details
-  (kbd "C") 'kubel-set-context
-  (kbd "n") 'kubel-set-namespace
-  (kbd "g") 'kubel-mode
-  (kbd "p") 'kubel-port-forward-pod
-  (kbd "l") 'kubel-log-popup
-  (kbd "c") 'kubel-copy-popup
-  (kbd "?") 'kubel-help-popup
-  (kbd "o") 'kubel-describe-popup
-  (kbd "e") 'kubel-exec-pod
-  (kbd "d") 'kubel-delete-popup
-  (kbd "a") 'kubel-jab-deployment)
+  (kbd "RET") #'kubel-get-pod-details
+  (kbd "C") #'kubel-set-context
+  (kbd "n") #'kubel-set-namespace
+  (kbd "g") #'kubel-mode
+  (kbd "p") #'kubel-port-forward-pod
+  (kbd "l") #'kubel-log-popup
+  (kbd "c") #'kubel-copy-popup
+  (kbd "?") #'kubel-help-popup
+  (kbd "o") #'kubel-describe-popup
+  (kbd "e") #'kubel-exec-pod
+  (kbd "d") #'kubel-delete-popup
+  (kbd "a") #'kubel-jab-deployment)
 
 (provide 'kubel-evil)


### PR DESCRIPTION
Hey, I saw your talk on youtube and your package was exactly what I was searching for. Thanks for creating it :slightly_smiling_face:. The only annoying thing for me is (because I'm an evil user) that I always have to switch to insert mode, before I can do actions. That's why I created some keybindings, when in motion, similar to the [kubernetes-evil](https://github.com/chrisbarrett/kubernetes-el/blob/master/kubernetes-evil.el) file.

I had to remap some stuff, because you should still be able to move up/down with j/k. Are those remaps fine or do you see a better fit? 

Also I'm not an expert in elisp and I don't know how to solve the problem in the best way: Currently the `kubel-help-popup` function doesn't show the right bindings when kubel-evil is loaded. Am I able to override your function or is it better to write another one and link that to my keybinding?