### PR TITLE
Close package requires list

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -26,7 +26,7 @@
 ;; Keywords: kubernetes k8s tools processes
 ;; URL: https://github.com/abrochard/kubel
 ;; License: GNU General Public License >= 3
-;; Package-Requires: ((transient "0.1.0") (emacs "25.3") (dash "2.17.0")
+;; Package-Requires: ((transient "0.1.0") (emacs "25.3") (dash "2.17.0"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
Currently, the MELPA page for kubel (https://melpa.org/#/kubel) shows no dependencies.