### PR TITLE
Fix default resource

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -131,7 +131,7 @@
 (defvar kubel-namespace "default"
   "Current namespace.")
 
-(defvar kubel-resource "pods"
+(defvar kubel-resource "Pods"
   "Current resource.")
 
 (defvar kubel-context


### PR DESCRIPTION
All other vars and fns use a capitalized "Pods". See `kubel--is-pod-view`, `kubel-kubernetes-resources-list` and numerous calls to `kubel--select-resource`.