### PR TITLE
add simple caching of kubernetes version and resources list

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -185,9 +185,20 @@
 	"RoleBindings"
 	"Roles"))
 
+(defvar kubel--kubernetes-version-cached nil)
+
+(defvar kubel--kubernetes-resources-list-cached nil)
+
+(defun kubel--invalidate-context-caches ()
+  (setq kubel--kubernetes-resources-list-cached nil)
+  (setq kubel--kubernetes-version-cached nil))
+
 (defun kubel-kubernetes-version ()
   "Return a list with (major-version minor-version patch)."
-  (let ((version-string (shell-command-to-string "kubectl version")))
+  (let ((version-string (if (null kubel--kubernetes-version-cached)
+                            (setq kubel--kubernetes-version-cached
+                                  (shell-command-to-string "kubectl version"))
+                          kubel--kubernetes-version-cached)))
     (string-match "GitVersion:\"v\\([0-9]*\\)\.\\([0-9]*\\)\.\\([0-9]*\\)\"" version-string)
     (list
      (string-to-number (match-string 1 version-string))
@@ -206,7 +217,6 @@ VERSION should be a list of (major-version minor-version patch)."
      (<= (nth 0 version) kubernetes-major-version)
      (or (<= (nth 1 version) kubernetes-minor-version) (< (nth 0 version) kubernetes-major-version))
      (or (<= (nth 2 version) kubernetes-patch-version) (< (nth 1 version) kubernetes-minor-version)))))
-
 
 (defun kubel--populate-list ()
   "Return a list with a tabulated list format and \"tabulated-list-entries\"."
@@ -540,16 +550,24 @@ ARGS is the arguments list from transient."
         (completing-read
          "Select context: "
          (split-string (shell-command-to-string "kubectl config view -o jsonpath='{.contexts[*].name}'") " ")))
+  (kubel--invalidate-context-caches)
   (kubel))
 
-(defun kubel-set-resource ()
-  "Set the resource."
-  (interactive)
+(defun kubel--fetch-api-resource-list ()
+  (split-string (shell-command-to-string "kubectl api-resources -o name --no-headers=true") "\n"))
+
+(defun kubel-set-resource (&optional refresh)
+  "Set the resource. If called with a prefix argument, refreshes
+the context caches, including the cached resource list."
+  (interactive "P")
+  (when refresh (kubel--invalidate-context-caches))
   (let ((current-buffer-name (kubel--buffer-name))
-        (resource-list
-         (if (kubel-kubernetes-compatible-p '(1 13 3))
-			 (split-string (shell-command-to-string "kubectl api-resources -o name --no-headers=true") "\n")
-		   kubel-kubernetes-resources-list)))
+        (resource-list (if (kubel-kubernetes-compatible-p '(1 13 3))
+	                   (if (null kubel--kubernetes-resources-list-cached)
+                               (setq kubel--kubernetes-resources-list-cached
+                                     (kubel--fetch-api-resource-list))
+                             kubel--kubernetes-resources-list-cached)
+	                 kubel-kubernetes-resources-list)))
     (setq kubel-resource
 	      (completing-read "Select resource: " resource-list))
     (when (get-buffer current-buffer-name) ;; kill the current buffer to avoid confusion


### PR DESCRIPTION
Hi! Fetching api-resources list and version on every call to `kubel-set-resource` slows down switching between resources.
Would you be interested in this patch that adds simple caching of these two?
This PR adds the following:
* caches values of api-resources list and K8s version
* invalidates caches on change of context
* enables `kubel-set-resource` to be run with prefix arg and to refresh the cache

Thank you for this great software, BTW. I really enjoy using it.