### PR TITLE
Fix kubel--is-pod-view is nil when `kubel-resource=pods`

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -412,7 +412,7 @@ TYPENAME is the resource type/name."
 
 (defun kubel--is-pod-view ()
   "Return non-nil if this is the pod view."
-  (equal kubel-resource "Pods"))
+  (equal (capitalize kubel-resource) "Pods"))
 
 (defun kubel--is-deployment-view ()
   "Return non-nil if this is the pod view."


### PR DESCRIPTION
Hi, Thanks for your great package.

I have a bit issue when using `kubel-get-pod-log` at cursor of a pod. This patch has help me.
And I hope it can be useful
Thanks