### PR TITLE
custom-column -> custom-columns

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -580,7 +580,7 @@ the context caches, including the cached resource list."
   (setq kubel-output
 	    (completing-read
 	     "Set output format: "
-	     '("yaml" "json" "wide" "custom-column=")))
+	     '("yaml" "json" "wide" "custom-columns=")))
   (kubel))
 
 (defun kubel-port-forward-pod (p)


### PR DESCRIPTION
The `-o` format for `kubectl` is `column-columns=`. See https://kubernetes.io/docs/reference/kubectl/overview/#syntax-1