### PR TITLE
Add kubel-exec-shell-pod

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -823,7 +823,7 @@ RESET is to be called if the search is nil after the first attempt."
 (define-transient-command kubel-exec-popup ()
   "Kubel Exec Menu"
   ["Actions"
-   ("f" "Find files" kubel-exec-pod)
+   ("d" "Dired" kubel-exec-pod)
    ("e" "Eshell" kubel-exec-eshell-pod)
    ("s" "Shell" kubel-exec-shell-pod)])
 

--- a/kubel.el
+++ b/kubel.el
@@ -534,7 +534,7 @@ ARGS is the arguments list from transient."
                  (append '("logs") (kubel--default-tail-arg args) (list pod container)) t)))
 
 (defun kubel-get-logs-by-labels (&optional args)
-  "Get the last N logs of the pods by labels
+  "Get the last N logs of the pods by labels.
 ARGS is the arguments list from transient."
   (interactive
    (list (transient-args 'kubel-log-popup)))
@@ -694,7 +694,7 @@ P can be a single number or a localhost:container port pair."
                  (tramp-remote-shell-args  ("-i" "-c"))))) ;; add the current context/namespace to tramp methods
 
 (defun kubel-exec-pod ()
-  "Exec into the pod under the cursor -> find-file."
+  "Exec into the pod under the cursor -> `find-file."
   (interactive)
   (kubel-setup-tramp)
   (setq dir-prefix (or


### PR DESCRIPTION
Hi @abrochard,

I would like to add `M-x kubel-exec-shell-pod` feature.

Basically, I can use `kubel-exec-pod` (find-file in pod) then `M-x shell` to open a shell. But it is quite inconvenient when it open a buffer `*shell*`, I always open shells in some pods together. So I have to rename the current buffer shell to open a new shell of the other pods.

By using `kubel-exec-shell-pod`, key binding is `b` (inspired by docker package). It opens a shell with `kubel - shell - pod` format. Help me can open more shell of other pods without rename shell buffer.

I hope it is useful. Thanks