### PR TITLE
kubel--can-get-namespace: Avoid spurious warning

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -588,7 +588,7 @@ ARGS is the arguments list from transient."
              (setq kubel--can-get-namespace-cached
                    (equal "yes\n"
                           (shell-command-to-string
-                           (format "kubectl --context %s auth can-i list namespaces" kubel-context))))))
+                           (format "kubectl --context %s auth can-i list namespaces --all-namespaces" kubel-context))))))
          kubel--can-get-namespace-cached)))
 
 (defun kubel--get-namespace ()


### PR DESCRIPTION
Hello and thank you for your work!

The resolution of issue #38 did not help me as a new user - being a K8S newbie and having just installed ```minikube```/```kubectl``` ```v1.19.4``` and ```kubel```, I couldn't understand why no namespaces were listed, as ```kubel-use-namespace-list``` was set to ```auto``` and ```kubectl --context minikube auth can-i list namespaces``` did return ```yes\n``` in its stdout after all.

By using ```--all-namespaces```, this warning disappears while still allowing ```kubel--can-get-namespace``` to fail on other kubectl stderr warnings.

This pull request does not address the separate issue of ```kubectl get namespaces``` not working even after ```kubectl can-i``` returned ```yes\n```, but I think it does increase the chances of the user getting a namespace list out of the box.

Feel free to reject in any case!