### PR TITLE
Support for multiple Kubel buffers, each one using a different combination of Contex, Namespace, Resource, Filters, and Labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,40 @@ load the `kubel-evil.el` file.
 
 ## Usage
 
-To list the pods in your current context and namespace, call
-```
-M-x kubel-refresh
-```
-To set said namespace and context, respectively call
-```
-M-x kubel-set-namespace
-M-x kubel-set-context
-```
-Note that context will autocomplete but not necessarily namespaces
-depending on your permissions and cluster setup.
-See the [customize section](#Customize) on how to tune `kubel-use-namespace-list`.
+### `M-x kubel`
 
-To switch to showing a different resource, use the `R` command or
-```
-M-x kubel-set-resource
-```
-This will let you select a resource and re-display the kubel buffer.
+Call `kubel` to open a new kubel buffer. Call `kubel` again to start a new
+session for a different context/namespace/resource.
 
-You can also use `kubel-open` to open directly a kubel buffer with the given parameters, example:
-``` lisp
-(kubel-open "custom-context" "custom-namespace" "custom-resource"))
+Each kubel buffer will automatically be renamed using the following template:
 ```
+*kubel session:  |<context>|<namespace>|<resource>|*
+```
+
+### `M-x kubel-refresh`
+
+Call `kubel-refresh` or hit `g` to refresh the current kubel buffer using the
+configured context/namespace/resource for that session.
+
+### `M-x kubel-open`
+
+Call `kubel-open` to programmatically open a new session for the passed context,
+namespace, and resource.
+
+```lisp
+(kubel-open "<context>" "<namespace>" "<resource>*kubel session:  |management-deploys-us-east1-2|gkrane-jobs|Pods|*")
+```
+
+### Changing context, namespace, and resource for a kubel session
+
+To change the context, namespace, or resource for a session, call:
+- `M-x kubel-set-context` or hit `C`.
+- `M-x kubel-set-namespace` or hit `n`.
+- `M-x kubel-set-resource` or hit `R`.
+
+Note that context will autocomplete but not necessarily namespaces depending on
+your permissions and cluster setup.  See the [customize section](#Customize) on
+how to tune `kubel-use-namespace-list`.
 
 ## Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ load the `kubel-evil.el` file.
 
 To list the pods in your current context and namespace, call
 ```
-M-x kubel
+M-x kubel-refresh
 ```
 To set said namespace and context, respectively call
 ```

--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ You can [watch how kubel started](https://www.youtube.com/watch?v=w3krYEeqnyk) o
 ## Features
 We now support managing pretty much any resource!
 
-- switch context and namespace
-- show any resource (pods/services/deployments/etc)
-- highlight a resource by name
-- copy resource name to clipboard
-- show and edit resource details
-- show rollout history for a resource
-- delete a resource
-- tail container logs (possibly with `-f` follow flag)
-- copy container log command to clipboard
-- port forward a pod to your localhost
-- exec into a pod using tramp
+- Switch context and namespace.
+- Show any resource (pods/services/deployments/etc).
+- Highlight a resource by name.
+- Copy resource name to clipboard.
+- Show and edit resource details.
+- Show rollout history for a resource.
+- Delete a resource.
+- Tail container logs (possibly with `-f` follow flag).
+- Copy container log command to clipboard.
+- Port forward a pod to your localhost.
+- Exec into a pod using tramp.
+- Multiple kubel buffers, each one with different context, namespace, and resource.
 
 ## Installation
 
@@ -51,6 +52,11 @@ To switch to showing a different resource, use the `R` command or
 M-x kubel-set-resource
 ```
 This will let you select a resource and re-display the kubel buffer.
+
+You can also use `kubel-open` to open directly a kubel buffer with the given parameters, example:
+``` lisp
+(kubel-open "custom-context" "custom-namespace" "custom-resource"))
+```
 
 ## Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each kubel buffer will automatically be renamed using the following template:
 
 ### `M-x kubel-refresh`
 
-Call `kubel-refresh` or hit `g` to refresh the current kubel buffer using the
+Call `kubel-refresh` or hit `g` (`x` in evil-mode) to refresh the current kubel buffer using the
 configured context/namespace/resource for that session.
 
 ### `M-x kubel-open`
@@ -81,7 +81,7 @@ h => help popup
 ? => help popup
 ! => quick run shell-command
 E => quick edit any resource
-g => refresh
+g => refresh (`x` in evil-mode)
 k => delete popup
 r => see the rollout history for resource
 p => port forward pod

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -77,7 +77,7 @@
     ;; global
     ("RET" "Resource details" kubel-describe-popup)
     ("E" "Quick edit" kubel-quick-edit)
-    ("g" "Refresh" kubel-refresh)
+    ("x" "Refresh" kubel-refresh)
     ("d" "Delete" kubel-delete-popup) ;; can't use k here
     ("r" "Rollout" kubel-rollout-history)]
    ["" ;; based on current view
@@ -112,7 +112,7 @@
   (kbd "K") #'kubel-set-kubectl-config-file
   (kbd "C") #'kubel-set-context
   (kbd "n") #'kubel-set-namespace
-  (kbd "g") #'kubel-refresh
+  (kbd "x") #'kubel-refresh
   (kbd "h") #'kubel-evil-help-popup
   (kbd "?") #'kubel-evil-help-popup
   (kbd "F") #'kubel-set-output-format

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -39,7 +39,7 @@
 ;; C => set context
 ;; n => set namespace
 ;; R => set resource
-;; g => refresh pods
+;; x => refresh pods
 ;; E => quick edit
 ;; p => port forward pod
 ;; e => exec into pod

--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -76,7 +76,7 @@
     ;; global
     ("RET" "Resource details" kubel-describe-popup)
     ("E" "Quick edit" kubel-quick-edit)
-    ("g" "Refresh" kubel)
+    ("g" "Refresh" kubel-refresh)
     ("d" "Delete" kubel-delete-popup) ;; can't use k here
     ("r" "Rollout" kubel-rollout-history)]
    ["" ;; based on current view
@@ -110,7 +110,7 @@
   (kbd "K") #'kubel-set-kubectl-config-file
   (kbd "C") #'kubel-set-context
   (kbd "n") #'kubel-set-namespace
-  (kbd "g") #'kubel
+  (kbd "g") #'kubel-refresh
   (kbd "h") #'kubel-evil-help-popup
   (kbd "?") #'kubel-evil-help-popup
   (kbd "F") #'kubel-set-output-format

--- a/kubel.el
+++ b/kubel.el
@@ -430,7 +430,7 @@ ARGS is a ist of arguments.
 READONLY If true buffer will be in readonly mode(view-mode)."
   (when (equal process-name "")
     (setq process-name "kubel-command"))
-  (let ((buffer-name (format "*%s*" process-name))
+  (let ((buffer-name (format "*kubel resource: |%s|%s|%s|*" kubel-context kubel-namespace (string-join args "_")))
         (error-buffer (kubel--process-error-buffer process-name))
         (cmd (append (list "kubectl") (kubel--get-context-namespace) args)))
     (when (get-buffer buffer-name)

--- a/kubel.el
+++ b/kubel.el
@@ -556,7 +556,7 @@ TYPENAME is the resource type/name."
   (equal (capitalize kubel-resource) "Pods"))
 
 (defun kubel--is-deployment-view ()
-  "Return non-nil if this is the pod view."
+  "Return non-nil if this is a deployment view."
   (-contains? '("Deployments" "deployments" "deployments.apps") kubel-resource))
 
 (defun kubel--is-scalable ()
@@ -579,12 +579,13 @@ TYPENAME is the resource type/name."
     (goto-line kubel--line-number)))
 
 ;; interactive
+;;;###autoload
 (define-minor-mode kubel-yaml-editing-mode
   "Kubel Yaml editing mode.
 Use C-c C-c to kubectl apply the current yaml buffer."
   :init-value nil
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-c C-c") 'kubel-apply)
+            (define-key map (kbd "C-c C-c") #'kubel-apply)
             map))
 
 (defun kubel-apply ()
@@ -595,7 +596,6 @@ Use C-c C-c to kubectl apply the current yaml buffer."
                       (with-parsed-tramp-file-name default-directory nil
                         (format "/%s%s:%s@%s:" (or hop "") method user host)))
                     ""))
-
   (let* ((filename-without-tramp-prefix (format "/tmp/kubel/%s-%s.yaml"
                                                 (replace-regexp-in-string "[^[:alnum:]-_]" "" (buffer-name))
                                                 (floor (float-time))))
@@ -799,7 +799,7 @@ ARGS is the arguments list from transient."
       (setq selector ""))
     (setq kubel-selector selector))
   (kubel--add-selector-to-history kubel-selector)
-  ; Update pod list according to the label selector
+  ;; Update pod list according to the label selector
   (kubel-refresh))
 
 (defun kubel--fetch-api-resource-list ()
@@ -832,9 +832,9 @@ the context caches, including the cached resource list."
   (setq kubel-output
         (completing-read
          "Set output format: "
-        (completing-read
-         "Set output format: "
-         '("yaml" "json" "wide" "custom-columns=")))))
+         (completing-read
+          "Set output format: "
+          '("yaml" "json" "wide" "custom-columns=")))))
 
 (defun kubel-port-forward-pod (p)
   "Port forward a pod to your local machine.

--- a/kubel.el
+++ b/kubel.el
@@ -604,15 +604,20 @@ Use C-c C-c to kubectl apply the current yaml buffer."
  DESCRIBE is the optional param to describe instead of get."
   (interactive "P")
   (let* ((resource (kubel--get-resource-under-cursor))
+         (ctx kubel-context)
+         (ns kubel-namespace)
+         (res kubel-resource)
          (process-name (format "kubel - %s - %s" kubel-resource resource)))
     (if describe
         (kubel--exec process-name (list "describe" kubel-resource (kubel--get-resource-under-cursor)))
       (kubel--exec process-name (list "get" kubel-resource (kubel--get-resource-under-cursor) "-o" kubel-output)))
     (when (or (string-equal kubel-output "yaml") (transient-args 'kubel-describe-popup))
       (yaml-mode)
-      (kubel-yaml-editing-mode))
-    (goto-char (point-min))))
-
+      (kubel-yaml-editing-mode)
+      (setq kubel-context ctx)
+      (setq kubel-namespace ns)
+      (setq kubel-resource res)
+      (goto-char (point-min)))))
 
 (defun kubel--default-tail-arg (args)
   "Ugly function to make sure that there is at least the default tail.

--- a/kubel.el
+++ b/kubel.el
@@ -588,10 +588,7 @@ Use C-c C-c to kubectl apply the current yaml buffer."
 		            ""))
 
   (let* ((filename-without-tramp-prefix (format "/tmp/kubel/%s-%s.yaml"
-						                        (replace-regexp-in-string "\*\\| " "" (buffer-name))
-						                        (floor (float-time))))
-	     (filename (format "%s%s" dir-prefix filename-without-tramp-prefix)))
-    (when (y-or-n-p "Apply the changes? ")
+                                                (replace-regexp-in-string "[^[:alnum:]-_]" "" (buffer-name))
       (unless  (file-exists-p (format "%s/tmp/kubel" dir-prefix))
 	    (make-directory (format "%s/tmp/kubel" dir-prefix) t))
       (write-region (point-min) (point-max) filename)

--- a/kubel.el
+++ b/kubel.el
@@ -375,7 +375,7 @@ If MAX is the end of the line, dynamically adjust."
 
 (defun kubel--buffer-name ()
   "Return kubel buffer name."
-  (concat (format "*kubel (%s) [%s]: %s" kubel-namespace kubel-context kubel-resource)
+  (concat (format "*kubel [%s] (%s): %s" kubel-context kubel-namespace kubel-resource)
           (unless (equal kubel-selector "")
             (format " (%s)" kubel-selector))
           "*"))

--- a/kubel.el
+++ b/kubel.el
@@ -70,7 +70,7 @@
 ;; h => help popup
 ;; ? => help popup
 ;; E => quick edit any resource
-;; x => refresh
+;; g => refresh
 ;; k => delete popup
 ;; r => see the rollout history for resource
 ;; p => port forward pod
@@ -1111,7 +1111,7 @@ RESET is to be called if the search is nil after the first attempt."
     ;; global
     ("RET" "Resource details" kubel-describe-popup)
     ("E" "Quick edit" kubel-quick-edit)
-    ("x" "Refresh" kubel-refresh)
+    ("g" "Refresh" kubel-refresh)
     ("k" "Delete" kubel-delete-popup)
     ("r" "Rollout" kubel-rollout-history)]
    ["" ;; based on current view
@@ -1148,7 +1148,7 @@ RESET is to be called if the search is nil after the first attempt."
     (define-key map (kbd "K") 'kubel-set-kubectl-config-file)
     (define-key map (kbd "C") 'kubel-set-context)
     (define-key map (kbd "n") 'kubel-set-namespace)
-    (define-key map (kbd "x") 'kubel-refresh)
+    (define-key map (kbd "g") 'kubel-refresh)
     (define-key map (kbd "h") 'kubel-help-popup)
     (define-key map (kbd "?") 'kubel-help-popup)
     (define-key map (kbd "F") 'kubel-set-output-format)

--- a/kubel.el
+++ b/kubel.el
@@ -373,9 +373,13 @@ If MAX is the end of the line, dynamically adjust."
   "Return the width of a specific COLNUM in ENTRYLIST."
   (seq-max (mapcar (lambda (x) (length (nth colnum x) )) entrylist)))
 
+(defun kubel--buffer-name-from-parameters (context namespace resource)
+  "Return a preconfigured kubel buffer name."
+  (concat (format "*kubel [%s] (%s): %s*" context namespace resource)))
+
 (defun kubel--buffer-name ()
   "Return kubel buffer name."
-  (concat (format "*kubel [%s] (%s): %s" kubel-context kubel-namespace kubel-resource)
+  (concat (kubel--buffer-name-from-parameters kubel-context kubel-namespace kubel-resource)
           (unless (equal kubel-selector "")
             (format " (%s)" kubel-selector))
           "*"))
@@ -1161,6 +1165,21 @@ DIRECTORY is optional for TRAMP support."
   (tabulated-list-print)
   (kubel--current-state)
   (kubel--jump-back-to-line))
+
+;;;###autoload
+(defun kubel-open (context namespace resource)
+  "Create a new kubel buffer using passed parameters CONTEXT NAMESPACE RESOURCE."
+  (let ((tmpname "*kubel-tmp*")
+        (name (kubel--buffer-name-from-parameters context namespace resource)))
+    (if (get-buffer name)
+        (pop-to-buffer-same-window name)
+      (with-current-buffer (get-buffer-create tmpname)
+        (kubel-mode)
+        (setq kubel-context context)
+        (setq kubel-namespace namespace)
+        (setq kubel-resource resource)
+        (pop-to-buffer-same-window tmpname)
+        (kubel-refresh)))))
 
 ;;;###autoload
 (defun kubel (&optional directory)

--- a/kubel.el
+++ b/kubel.el
@@ -377,7 +377,7 @@ If MAX is the end of the line, dynamically adjust."
 
 (defun kubel--buffer-name-from-parameters (context namespace resource)
   "Return a preconfigured kubel buffer name."
-  (concat (format "*kubel manager:  |%s|%s|%s|*" context namespace resource)))
+  (concat (format "*kubel session:  |%s|%s|%s|*" context namespace resource)))
 
 (defun kubel--buffer-name ()
   "Return kubel buffer name."
@@ -1229,7 +1229,6 @@ DIRECTORY is optional for TRAMP support."
 ;;;###autoload
 (defun kubel (&optional directory)
   "Invoke the kubel buffer.
-
 DIRECTORY is optional for TRAMP support."
   (interactive)
 

--- a/kubel.el
+++ b/kubel.el
@@ -173,7 +173,7 @@ off - always assume we cannot list namespaces"
     (goto-char (point-max))
     (insert (format "%s\n" str))))
 
-(defvar kubel--last-command nil)
+(defvar-local kubel--last-command nil)
 
 (defun kubel--log-command (process-name cmd)
   "Log the kubectl command to the process buffer.
@@ -192,24 +192,24 @@ CMD is the command string to run."
   (kubel--log-command "kubectl-command" cmd)
   (shell-command-to-string cmd))
 
-(defvar kubel-namespace "default"
+(defvar-local kubel-namespace "default"
   "Current namespace.")
 
-(defvar kubel-resource "Pods"
+(defvar-local kubel-resource "Pods"
   "Current resource.")
 
-(defvar kubel-context
+(defvar-local kubel-context
   (replace-regexp-in-string
    "\n" "" (kubel--exec-to-string "kubectl config current-context"))
   "Current context.  Tries to smart default.")
 
-(defvar kubel-resource-filter ""
+(defvar-local kubel-resource-filter ""
   "Substring filter for resource name.")
 
-(defvar kubel-selector ""
+(defvar-local kubel-selector ""
   "Label selector for resources.")
 
-(defvar kubel--line-number nil
+(defvar-local kubel--line-number nil
   "Store the current line number to jump back after a refresh.")
 
 (defvar kubel-namespace-history '()
@@ -244,17 +244,17 @@ CMD is the command string to run."
 	"RoleBindings"
 	"Roles"))
 
-(defvar kubel--kubernetes-version-cached nil)
+(defvar-local kubel--kubernetes-version-cached nil)
 
 (defvar kubel--kubernetes-resources-list-cached nil)
 
-(defvar kubel--can-get-namespace-cached nil)
+(defvar-local kubel--can-get-namespace-cached nil)
 
 (defvar kubel--namespace-list-cached nil)
 
-(defvar kubel--label-values-cached nil)
+(defvar-local kubel--label-values-cached nil)
 
-(defvar kubel--selected-items '())
+(defvar-local kubel--selected-items '())
 
 (defun kubel--invalidate-context-caches ()
   "Invalidate the context caches."
@@ -1132,7 +1132,7 @@ RESET is to be called if the search is nil after the first attempt."
     map)
   "Keymap for `kubel-mode'.")
 
-(defvar kubel-last-position nil)
+(defvar-local kubel-last-position nil)
 
 ;;;###autoload
 (defun kubel (&optional directory)

--- a/kubel.el
+++ b/kubel.el
@@ -813,11 +813,11 @@ the context caches, including the cached resource list."
   "Set output format of kubectl."
   (interactive)
   (setq kubel-output
-	    (completing-read
-	     "Set output format: "
         (completing-read
          "Set output format: "
-         '("yaml" "json" "wide" "custom-columns="))))
+        (completing-read
+         "Set output format: "
+         '("yaml" "json" "wide" "custom-columns=")))))
 
 (defun kubel-port-forward-pod (p)
   "Port forward a pod to your local machine.

--- a/kubel.el
+++ b/kubel.el
@@ -70,7 +70,7 @@
 ;; h => help popup
 ;; ? => help popup
 ;; E => quick edit any resource
-;; g => refresh
+;; x => refresh
 ;; k => delete popup
 ;; r => see the rollout history for resource
 ;; p => port forward pod
@@ -1111,7 +1111,7 @@ RESET is to be called if the search is nil after the first attempt."
     ;; global
     ("RET" "Resource details" kubel-describe-popup)
     ("E" "Quick edit" kubel-quick-edit)
-    ("g" "Refresh" kubel-refresh)
+    ("x" "Refresh" kubel-refresh)
     ("k" "Delete" kubel-delete-popup)
     ("r" "Rollout" kubel-rollout-history)]
    ["" ;; based on current view
@@ -1148,7 +1148,7 @@ RESET is to be called if the search is nil after the first attempt."
     (define-key map (kbd "K") 'kubel-set-kubectl-config-file)
     (define-key map (kbd "C") 'kubel-set-context)
     (define-key map (kbd "n") 'kubel-set-namespace)
-    (define-key map (kbd "g") 'kubel-refresh)
+    (define-key map (kbd "x") 'kubel-refresh)
     (define-key map (kbd "h") 'kubel-help-popup)
     (define-key map (kbd "?") 'kubel-help-popup)
     (define-key map (kbd "F") 'kubel-set-output-format)

--- a/kubel.el
+++ b/kubel.el
@@ -375,7 +375,7 @@ If MAX is the end of the line, dynamically adjust."
 
 (defun kubel--buffer-name-from-parameters (context namespace resource)
   "Return a preconfigured kubel buffer name."
-  (concat (format "*kubel [%s] (%s): %s*" context namespace resource)))
+  (concat (format "*kubel manager: |%s|%s|%s|*" context namespace resource)))
 
 (defun kubel--buffer-name ()
   "Return kubel buffer name."

--- a/kubel.el
+++ b/kubel.el
@@ -589,6 +589,9 @@ Use C-c C-c to kubectl apply the current yaml buffer."
 
   (let* ((filename-without-tramp-prefix (format "/tmp/kubel/%s-%s.yaml"
                                                 (replace-regexp-in-string "[^[:alnum:]-_]" "" (buffer-name))
+                                                (floor (float-time))))
+         (filename (format "%s%s" dir-prefix filename-without-tramp-prefix)))
+    (when (y-or-n-p (format "Apply the changes %s? " filename))
       (unless  (file-exists-p (format "%s/tmp/kubel" dir-prefix))
 	    (make-directory (format "%s/tmp/kubel" dir-prefix) t))
       (write-region (point-min) (point-max) filename)

--- a/kubel.el
+++ b/kubel.el
@@ -381,8 +381,7 @@ If MAX is the end of the line, dynamically adjust."
   "Return kubel buffer name."
   (concat (kubel--buffer-name-from-parameters kubel-context kubel-namespace kubel-resource)
           (unless (equal kubel-selector "")
-            (format " (%s)" kubel-selector))
-          "*"))
+            (format " (%s)" kubel-selector))))
 
 (defun kubel--items-selected-p ()
   "Return non-nil if there are items selected."

--- a/kubel.el
+++ b/kubel.el
@@ -375,7 +375,7 @@ If MAX is the end of the line, dynamically adjust."
 
 (defun kubel--buffer-name-from-parameters (context namespace resource)
   "Return a preconfigured kubel buffer name."
-  (concat (format "*kubel manager: |%s|%s|%s|*" context namespace resource)))
+  (concat (format "*kubel manager:  |%s|%s|%s|*" context namespace resource)))
 
 (defun kubel--buffer-name ()
   "Return kubel buffer name."

--- a/kubel.el
+++ b/kubel.el
@@ -1211,8 +1211,9 @@ DIRECTORY is optional for TRAMP support."
   (kubel--jump-back-to-line))
 
 ;;;###autoload
-(defun kubel-open (context namespace resource)
-  "Create a new kubel buffer using passed parameters CONTEXT NAMESPACE RESOURCE."
+(defun kubel-open (context namespace resource &optional directory)
+  "Create a new kubel buffer using passed parameters CONTEXT NAMESPACE RESOURCE.
+DIRECTORY is optional for TRAMP support."
   (let ((tmpname "*kubel-tmp*")
         (name (kubel--buffer-name-from-parameters context namespace resource)))
     (if (get-buffer name)
@@ -1223,7 +1224,7 @@ DIRECTORY is optional for TRAMP support."
         (setq kubel-namespace namespace)
         (setq kubel-resource resource)
         (pop-to-buffer-same-window tmpname)
-        (kubel-refresh)))))
+        (kubel-refresh directory)))))
 
 ;;;###autoload
 (defun kubel (&optional directory)


### PR DESCRIPTION
Add support to have multiple and functional kubel buffers, each one using a different combination of Contex, Namespace, Resource, Filters, Labels, last command,

![image](https://user-images.githubusercontent.com/950087/133546894-919664f6-d672-4e94-bb14-795c19357dfd.png)

Closes https://github.com/abrochard/kubel/issues/54

Some notes:
- Kubel mode is only set once when the buffer is created.
- Now when `kubel` is called, it'll always create a new buffer with fresh variables for
- context, namespace, and resource.
- Stop killing existing buffer when changing objects, instead, a new function
- `kubel-refresh` is now taking care of displaying/refreshing current configuration.
- Show a message when the command is being executed, to easily tell if a command
  is being executed.
