### PR TITLE
kubel-exec-pod-by-shell-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - `kubectl` apply a buffer to current context/namespace
 
 ### Added
-- `kubel-exec-pod-by-shell-command` by using shell-command we can run fast a command
+- `kubel-exec-pod-by-shell-command` by using shell-command we can quickly run a command.
 
 ## [3.0.0] -
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - run `kubectl describe pod`
 - `kubectl` apply a buffer to current context/namespace
 
+### Added
+- `kubel-exec-pod-by-shell-command` by using shell-command we can run fast a command
+
 ## [3.0.0] -
 ### Added
 - tailing logs of init container

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We now support managing pretty much any resource!
 - copy container log command to clipboard
 - port forward a pod to your localhost
 - exec into a pod using tramp
+- run fast shell-command
 
 ## Installation
 
@@ -60,6 +61,7 @@ enter => get resource details
 C-u enter => describe resource
 h => help popup
 ? => help popup
+! => run fast shell-command
 E => quick edit any resource
 g => refresh
 k => delete popup

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We now support managing pretty much any resource!
 - copy container log command to clipboard
 - port forward a pod to your localhost
 - exec into a pod using tramp
-- run fast shell-command
+- quick run shell-command
 
 ## Installation
 
@@ -61,7 +61,7 @@ enter => get resource details
 C-u enter => describe resource
 h => help popup
 ? => help popup
-! => run fast shell-command
+! => quick run shell-command
 E => quick edit any resource
 g => refresh
 k => delete popup

--- a/kubel.el
+++ b/kubel.el
@@ -1039,6 +1039,7 @@ RESET is to be called if the search is nil after the first attempt."
 (define-transient-command kubel-exec-popup ()
   "Kubel Exec Menu"
   ["Actions"
+   ("!" "Shell command" kubel-exec-pod-by-shell-command)
    ("d" "Dired" kubel-exec-pod)
    ("e" "Eshell" kubel-exec-eshell-pod)
    ("s" "Shell" kubel-exec-shell-pod)])

--- a/kubel.el
+++ b/kubel.el
@@ -1039,7 +1039,6 @@ RESET is to be called if the search is nil after the first attempt."
 (define-transient-command kubel-exec-popup ()
   "Kubel Exec Menu"
   ["Actions"
-   ("!" "Shell command" kubel-exec-pod-by-shell-command)
    ("d" "Dired" kubel-exec-pod)
    ("e" "Eshell" kubel-exec-eshell-pod)
    ("s" "Shell" kubel-exec-shell-pod)])

--- a/kubel.el
+++ b/kubel.el
@@ -898,6 +898,20 @@ P can be a single number or a localhost:container port pair."
          (eshell-buffer-name (format "*kubel - eshell - %s@%s*" container pod)))
     (eshell)))
 
+(defun kubel-exec-pod-by-shell-command ()
+  "Prompt shell with kubectl exec command at pod under cursor."
+  (interactive)
+  (kubel-setup-tramp)
+  (let* ((pod (if (kubel--is-pod-view)
+                  (kubel--get-resource-under-cursor)
+                (kubel--select-resource "Pods")))
+         (containers (kubel--get-containers pod))
+         (container (if (equal (length containers) 1)
+                        (car containers)
+                      (completing-read "Select container: " containers)))
+         (command (read-string "Shell command: " (format "%s exec %s -c %s -- " (kubel--get-command-prefix) pod container))))
+    (shell-command command)))
+
 (defun kubel-delete-resource ()
   "Kubectl delete resource under cursor."
   (interactive)
@@ -1025,6 +1039,7 @@ RESET is to be called if the search is nil after the first attempt."
 (define-transient-command kubel-exec-popup ()
   "Kubel Exec Menu"
   ["Actions"
+   ("!" "Shell command" kubel-exec-pod-by-shell-command)
    ("d" "Dired" kubel-exec-pod)
    ("e" "Eshell" kubel-exec-eshell-pod)
    ("s" "Shell" kubel-exec-shell-pod)])
@@ -1122,6 +1137,7 @@ RESET is to be called if the search is nil after the first attempt."
     (define-key map (kbd "l") 'kubel-log-popup)
     (define-key map (kbd "c") 'kubel-copy-popup)
     (define-key map (kbd "e") 'kubel-exec-popup)
+    (define-key map (kbd "!") 'kubel-exec-pod-by-shell-command)
     (define-key map (kbd "j") 'kubel-jab-deployment)
 
     (define-key map (kbd "m") 'kubel-mark-item)


### PR DESCRIPTION
Hi,

I don't know this feature is useful for everyone or not. But it helps me in some cases. Example run `ip a`, `nslookup`, some command to control something.