### PR TITLE
Prevent split-string return a list contains ""

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -538,7 +538,7 @@ NAME is the resource name."
 
 TYPENAME is the resource type/name."
   (let ((cmd (format "%s rollout history %s" (kubel--get-command-prefix) typename)))
-    (nthcdr 2 (split-string (kubel--exec-to-string cmd) "\n"))))
+    (nthcdr 2 (split-string (kubel--exec-to-string cmd) "\n" t))))
 
 (defun kubel--select-rollout (typename)
   "Select a rollout version.
@@ -798,7 +798,7 @@ ARGS is the arguments list from transient."
 (defun kubel--fetch-api-resource-list ()
   "Fetch the API resource list."
   (split-string (kubel--exec-to-string
-                 (format "kubectl --context %s api-resources -o name --no-headers=true" kubel-context)) "\n"))
+                 (format "kubectl --context %s api-resources -o name --no-headers=true" kubel-context)) "\n" t))
 
 (defun kubel-set-resource (&optional refresh)
   "Set the resource.


### PR DESCRIPTION
When begin using `vertico-mode` I have better view to see resources list has some candidate is "".

![Screenshot from 2021-09-30 23-08-58](https://user-images.githubusercontent.com/9713793/135492644-b7605aea-cf2f-4914-b135-8ac3f0208506.png)
![Screenshot from 2021-09-30 23-09-50](https://user-images.githubusercontent.com/9713793/135492646-7dd2c92c-b876-4ce4-8c9f-54ba3323b9e0.png)
