### PR TITLE
Fix kubel--can-get-namespace returning wrong value if kubectl returns a warning

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -735,7 +735,7 @@ ARGS is the arguments list from transient."
          (progn
            (unless kubel--can-get-namespace-cached
              (setq kubel--can-get-namespace-cached
-                   (equal "yes\n"
+                   (string-match-p "yes\n"
                           (kubel--exec-to-string
                            (format "kubectl --context %s auth can-i list namespaces" kubel-context))))))
          kubel--can-get-namespace-cached)))


### PR DESCRIPTION
While testing the kubel with a local minikube installation, I was surprised to not see the namespace auto populating.

Turns out my kubectl was returning a warning in the command to check if I had permissions:
```
$ kubectl auth can-i list namespace
Warning: resource 'namespaces' is not namespace scoped
yes
```

I changed the test to ensure that as long as "yes" is in the result the test passes.

Disclamer: I know next to no elisp so if there's a better way of doing this please let me know!