### PR TITLE
feat: custom for using same buffer for output

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -159,6 +159,11 @@ off - always assume we cannot list namespaces"
   :group 'kubel
   :options '('auto 'on 'off))
 
+(defcustom kubel-same-buffer 'nil
+	"Use the same buffer for output."
+	:type 'boolean
+	:group 'kubel)
+
 (defun kubel--append-to-process-buffer (str)
   "Append string STR to the process buffer."
   (with-current-buffer (get-buffer-create kubel--process-buffer)
@@ -464,7 +469,9 @@ READONLY If true buffer will be in readonly mode(view-mode)."
                   :file-handler t
                   :stderr error-buffer
                   :command cmd)
-    (pop-to-buffer buffer-name)
+    (if kubel-same-buffer
+        (pop-to-buffer-same-window buffer-name)
+      (pop-to-buffer buffer-name))
     (if readonly
         (with-current-buffer buffer-name
           (view-mode)))))


### PR DESCRIPTION
Most time I want to use the same buffer as the list of resource to describe the resource. So I made a custom that I can toggle. It defaults to the old behaviour.