### PR TITLE
Add a `kubel-kubectl` option & use it wherever kubectl should be used

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -769,7 +769,7 @@ ARGS is the arguments list from transient."
   (interactive)
   (let* ((namespace (completing-read "Namespace: " (kubel--list-namespace)
                                      nil nil nil nil "default"))
-         ( kubel--buffer (get-buffer (kubel--buffer-name)))
+         (kubel--buffer (get-buffer (kubel--buffer-name)))
          (last-default-directory (when kubel--buffer
                                    (with-current-buffer kubel--buffer default-directory))))
     (when kubel--buffer (kill-buffer kubel--buffer))

--- a/kubel.el
+++ b/kubel.el
@@ -873,7 +873,7 @@ P can be a single number or a localhost:container port pair."
   ;; TODO error message if resource is not pod
   (add-to-list 'tramp-methods
                `("kubectl"
-                 (tramp-login-program      kubel-kubectl)
+                 (tramp-login-program      ,kubel-kubectl)
                  (tramp-login-args         (,(kubel--get-context-namespace) ("exec" "-it") ("-c" "%u") ("%h") ("sh")))
                  (tramp-remote-shell       "sh")
                  (tramp-remote-shell-args  ("-i" "-c"))))) ;; add the current context/namespace to tramp methods


### PR DESCRIPTION
We use [aws-vault](https://github.com/99designs/aws-vault) to secure access to our Kubernetes cluster. In kubernetes-el, I was able to set `kubernetes-kubectl-executable` to point to this shell script:

```sh
#!/usr/bin/env bash

AWS_PROFILE="production"

/usr/bin/aws-vault exec \
		   "${AWS_PROFILE}" \
		   --prompt=zenity \
		   -- \
		   /home/john/.asdf/shims/kubectl "${@}"

```

This allowed me to run kubectl via aws-vault. I set aws-vault to show a GUI prompt when 2FA details are needed - just to keep things simple.

This PR allows attempts to achieve the same thing with kubel.

This is literally the first time I've ever modified an Emacs package.