### PR TITLE
Fix tramp-error Method 'kubectl' is not known.

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -1327,5 +1327,11 @@ DIRECTORY is optional for TRAMP support."
   (hl-line-mode 1)
   (run-mode-hooks 'kubel-mode-hook))
 
+(add-hook 'kubel-mode-hook #'kubel--jump-back-to-line)
+
+(eval-after-load 'tramp
+  '(progn
+     (kubel-setup-tramp)))
+
 (provide 'kubel)
 ;;; kubel.el ends here

--- a/kubel.el
+++ b/kubel.el
@@ -1327,7 +1327,6 @@ DIRECTORY is optional for TRAMP support."
   (hl-line-mode 1)
   (run-mode-hooks 'kubel-mode-hook))
 
-(add-hook 'kubel-mode-hook #'kubel--jump-back-to-line)
 
 (eval-after-load 'tramp
   '(progn


### PR DESCRIPTION

I encountered the same problem as #28, and solved it in this way.