### PR TITLE
Try to kill kubel buffer after prompting for new the context

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -782,11 +782,11 @@ ARGS is the arguments list from transient."
   (interactive)
   (let* ((kubel--buffer (get-buffer (kubel--buffer-name)))
          (last-default-directory (when kubel--buffer (with-current-buffer kubel--buffer default-directory))))
-    (when kubel--buffer (kill-buffer kubel--buffer));; kill buffer for previous context if possible
     (setq kubel-context
           (completing-read
            "Select context: "
            (split-string (kubel--exec-to-string (format "%s config view -o jsonpath='{.contexts[*].name}'" kubel-kubectl)) " ")))
+    (when kubel--buffer (kill-buffer kubel--buffer));; kill buffer for previous context if possible
     (kubel--invalidate-context-caches)
     (setq kubel-namespace "default")
     (kubel last-default-directory)))


### PR DESCRIPTION
When calling kubel-set-context from the main kubel buffer, killing the kubel
buffer prior to asking for the new context results in the default-directory of
the prompt being the default-directory of whichever buffer takes the place of
the kubel buffer. This can cause issues if the new buffer is remote via tramp,
which can often be the case with kubel. An example workflow where this is an
issue:

1. Execute an action on a pod, for example opening a shell to a container
2. After establishing the TRAMP connection to the container, switch back to the
   main kubel buffer in the same window
3. Invoke kubel-set-context

With the current implementation, the kubel buffer will be killed, putting the
container shell at the foreground of the window. The kubel--exec-to-string is
invoked through the TRAMP connection, and none of the existing contexts are
available for selection.

With this change, the kubel--exec-to-string is executed with the
default-directory of the existing kubel buffer, and the correct contexts will
be available.