### PR TITLE
Use faces to propertize status

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -116,27 +116,95 @@
   '("NAME" . nil)
   "Sort table on this key.")
 
-(defcustom kubel-status-colors
-  '(("Running" . "green")
-    ("Healthy" . "green")
-    ("Active" . "green")
-    ("Ready" . "green")
-    ("True" . "green")
-    ("Unknown" . "orange")
-    ("Error" . "red")
-    ("Evicted" . "red")
-    ("MemoryPressure" . "red")
-    ("PIDPressure" . "red")
-    ("DiskPressure" . "red")
-    ("RevisionMissing" . "red")
-    ("RevisionFailed" . "red")
-    ("NetworkUnavailable" . "red")
-    ("Completed" . "yellow")
-    ("CrashLoopBackOff" . "red")
-    ("Terminating" . "blue"))
-  "Associative list of status to color."
+(defface kubel-status-running
+  '((default . (:foreground "green")))
+  "The face to use for the Running status")
+
+(defface kubel-status-healthy
+  '((default . (:foreground "green")))
+  "The face to use for the Healthy status")
+
+(defface kubel-status-active
+  '((default . (:foreground "green")))
+  "The face to use for the Active status")
+
+(defface kubel-status-ready
+  '((default . (:foreground "green")))
+  "The face to use for the Ready status")
+
+(defface kubel-status-true
+  '((default . (:foreground "green")))
+  "The face to use for the True status")
+
+(defface kubel-status-unknown
+  '((default . (:foreground "orange")))
+  "The face to use for the Unknown status")
+
+(defface kubel-status-error
+  '((default . (:foreground "red")))
+  "The face to use for the Error status")
+
+(defface kubel-status-evicted
+  '((default . (:foreground "red")))
+  "The face to use for the Evicted status")
+
+(defface kubel-status-memory-pressure
+  '((default . (:foreground "red")))
+  "The face to use for the Memory Pressure status")
+
+(defface kubel-status-pid-pressure
+  '((default . (:foreground "red")))
+  "The face to use for the PID Pressure status")
+
+(defface kubel-status-disk-pressure
+  '((default . (:foreground "red")))
+  "The face to use for the Disk Pressure status")
+
+(defface kubel-status-revision-missing
+  '((default . (:foreground "red")))
+  "The face to use for the Revision Missing status")
+
+(defface kubel-status-revision-failed
+  '((default . (:foreground "red")))
+  "The face to use for the Revision Failed status")
+
+(defface kubel-status-network-unavailable
+  '((default . (:foreground "red")))
+  "The face to use for the Network Unavailable status")
+
+(defface kubel-status-completed
+  '((default . (:foreground "yellow")))
+  "The face to use for the Completed status")
+
+(defface kubel-status-crash-loop-backoff
+  '((default . (:foreground "red")))
+  "The face to use for the Crash Loop Backoff status")
+
+(defface kubel-status-terminating
+  '((default . (:foreground "blue")))
+  "The face to use for the Terminating status")
+
+(defcustom kubel-status-faces
+  '(("Running" . kubel-status-running)
+    ("Healthy" . kubel-status-healthy)
+    ("Active" . kubel-status-active)
+    ("Ready" . kubel-status-ready)
+    ("True" . kubel-status-true)
+    ("Unknown" . kubel-status-unknown)
+    ("Error" . kubel-status-error)
+    ("Evicted" . kubel-status-evicted)
+    ("MemoryPressure" . kubel-status-memory-pressure)
+    ("PIDPressure" . kubel-status-pid-pressure)
+    ("DiskPressure" . kubel-status-disk-pressure)
+    ("RevisionMissing" . kubel-status-revision-missing)
+    ("RevisionFailed" . kubel-status-revision-failed)
+    ("NetworkUnavailable" . kubel-status-network-unavailable)
+    ("Completed" . kubel-status-completed)
+    ("CrashLoopBackOff" . kubel-status-crash-loop-backoff)
+    ("Terminating" . kubel-status-terminating))
+  "Associative list of status to face."
   :type '(alist :key-type string
-                :value-type string)
+                :value-type face)
   :group 'kubel)
 
 (defcustom kubel-kubectl "kubectl"
@@ -421,10 +489,10 @@ If MAX is the end of the line, dynamically adjust."
   "Return the status in proper font color.
 
 STATUS is the pod status string."
-  (let ((pair (cdr (assoc status kubel-status-colors)))
+  (let ((status-face (cdr (assoc status kubel-status-faces)))
         (match (or (equal kubel-resource-filter "") (string-match-p kubel-resource-filter status)))
         (selected (and (kubel--items-selected-p) (-contains? kubel--selected-items status))))
-    (cond (pair (propertize status 'font-lock-face `(:foreground ,pair)))
+    (cond (status-face (propertize status 'face status-face))
           (selected (propertize (concat "*" status) 'face 'dired-marked))
           ((not match) (propertize status 'face 'shadow))
           (t status))))

--- a/kubel.el
+++ b/kubel.el
@@ -117,72 +117,72 @@
   "Sort table on this key.")
 
 (defface kubel-status-running
-  '((default . (:foreground "green")))
-  "The face to use for the Running status")
+  '((default . (:inherit success)))
+  "The face to use for the Running status.")
 
 (defface kubel-status-healthy
-  '((default . (:foreground "green")))
-  "The face to use for the Healthy status")
+  '((default . (:inherit success)))
+  "The face to use for the Healthy status.")
 
 (defface kubel-status-active
-  '((default . (:foreground "green")))
-  "The face to use for the Active status")
+  '((default . (:inherit success)))
+  "The face to use for the Active status.")
 
 (defface kubel-status-ready
-  '((default . (:foreground "green")))
-  "The face to use for the Ready status")
+  '((default . (:inherit success)))
+  "The face to use for the Ready status.")
 
 (defface kubel-status-true
-  '((default . (:foreground "green")))
-  "The face to use for the True status")
+  '((default . (:inherit success)))
+  "The face to use for the True status.")
 
 (defface kubel-status-unknown
-  '((default . (:foreground "orange")))
-  "The face to use for the Unknown status")
+  '((default . (:inherit warning)))
+  "The face to use for the Unknown status.")
 
 (defface kubel-status-error
-  '((default . (:foreground "red")))
-  "The face to use for the Error status")
+  '((default . (:inherit error)))
+  "The face to use for the Error status.")
 
 (defface kubel-status-evicted
-  '((default . (:foreground "red")))
-  "The face to use for the Evicted status")
+  '((default . (:inherit error)))
+  "The face to use for the Evicted status.")
 
 (defface kubel-status-memory-pressure
-  '((default . (:foreground "red")))
-  "The face to use for the Memory Pressure status")
+  '((default . (:inherit error)))
+  "The face to use for the Memory Pressure status.")
 
 (defface kubel-status-pid-pressure
-  '((default . (:foreground "red")))
-  "The face to use for the PID Pressure status")
+  '((default . (:inherit error)))
+  "The face to use for the PID Pressure status.")
 
 (defface kubel-status-disk-pressure
-  '((default . (:foreground "red")))
-  "The face to use for the Disk Pressure status")
+  '((default . (:inherit error)))
+  "The face to use for the Disk Pressure status.")
 
 (defface kubel-status-revision-missing
-  '((default . (:foreground "red")))
-  "The face to use for the Revision Missing status")
+  '((default . (:inherit error)))
+  "The face to use for the Revision Missing status.")
 
 (defface kubel-status-revision-failed
-  '((default . (:foreground "red")))
-  "The face to use for the Revision Failed status")
+  '((default . (:inherit error)))
+  "The face to use for the Revision Failed status.")
 
 (defface kubel-status-network-unavailable
-  '((default . (:foreground "red")))
-  "The face to use for the Network Unavailable status")
+  '((default . (:inherit error)))
+  "The face to use for the Network Unavailable status.")
 
 (defface kubel-status-completed
   '((default . (:foreground "yellow")))
-  "The face to use for the Completed status")
+  "The face to use for the Completed status.")
 
 (defface kubel-status-crash-loop-backoff
-  '((default . (:foreground "red")))
-  "The face to use for the Crash Loop Backoff status")
+  '((default . (:inherit error)))
+  "The face to use for the Crash Loop Backoff status.")
 
 (defface kubel-status-terminating
   '((default . (:foreground "blue")))
-  "The face to use for the Terminating status")
+  "The face to use for the Terminating status.")
 
 (defcustom kubel-status-faces
   '(("Running" . kubel-status-running)

--- a/kubel.el
+++ b/kubel.el
@@ -423,7 +423,7 @@ STATUS is the pod status string."
         (selected (and (kubel--items-selected-p) (-contains? kubel--selected-items status))))
     (cond (pair (propertize status 'font-lock-face `(:foreground ,pair)))
           (selected (propertize (concat "*" status) 'face 'dired-marked))
-          ((not match) (propertize status 'font-lock-face '(:foreground "darkgrey")))
+          ((not match) (propertize status 'face 'shadow))
           (t status))))
 
 (defun kubel--pop-to-buffer (name)

--- a/kubel.el
+++ b/kubel.el
@@ -116,7 +116,7 @@
   '("NAME" . nil)
   "Sort table on this key.")
 
-(defconst kubel--status-colors
+(defcustom kubel-status-colors
   '(("Running" . "green")
     ("Healthy" . "green")
     ("Active" . "green")
@@ -134,7 +134,10 @@
     ("Completed" . "yellow")
     ("CrashLoopBackOff" . "red")
     ("Terminating" . "blue"))
-  "Associative list of status to color.")
+  "Associative list of status to color."
+  :type '(alist :key-type string
+                :value-type string)
+  :group 'kubel)
 
 (defcustom kubel-kubectl "kubectl"
   "Kubectl binary path."
@@ -418,7 +421,7 @@ If MAX is the end of the line, dynamically adjust."
   "Return the status in proper font color.
 
 STATUS is the pod status string."
-  (let ((pair (cdr (assoc status kubel--status-colors)))
+  (let ((pair (cdr (assoc status kubel-status-colors)))
         (match (or (equal kubel-resource-filter "") (string-match-p kubel-resource-filter status)))
         (selected (and (kubel--items-selected-p) (-contains? kubel--selected-items status))))
     (cond (pair (propertize status 'font-lock-face `(:foreground ,pair)))


### PR DESCRIPTION
Currently we are hard-coding arbitrary colors for the statuses. With the theme ef-summer the contrast with chosen colors is not great. This PR lets the user customize the colors to fix the problem on their.

![image](https://user-images.githubusercontent.com/387111/187121940-76b21df1-bd89-4277-90f8-93a55b745da3.png)

Ideally I would like to suggest the use of either built-in or newly defined-faces for this purpose, but I wanted to ask you what if you'd like that before I included that change. f/e we can replace (:foreground "red) with the built-in error face, green one with success and the orange coloured one with warning. That way it would be more likely that kubel plays well with the user's theme