### PR TITLE
Make vterm option in kubel-exec-pod opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Get it from Melpa, or copy and load the `kubel.el` file.
 If you want to have the evil compatibility package, get it from Melpa as well or
 load the `kubel-evil.el` file.
 
+# Setup
+
+```elisp
+(require 'kubel)
+(kubel-vterm-setup) ; If you wish to have vterm as an option when using exec
+```
+
+Or if one uses `use-package`
+
+```elisp
+(use-package kubel
+  :after (vterm)
+  :config (kubel-vterm-setup))
+```
+
 ## Usage
 
 To list the pods in your current context and namespace, call

--- a/kubel.el
+++ b/kubel.el
@@ -1007,7 +1007,6 @@ P can be a single number or a localhost:container port pair."
 (defun kubel-exec-vterm-pod ()
   "Exec into the pod under the cursor -> vterm."
   (interactive)
-  (require 'vterm)
   (kubel-setup-tramp)
   (let* ((dir-prefix (kubel--dir-prefix))
          (con-pod (kubel--get-container-under-cursor))
@@ -1017,6 +1016,13 @@ P can be a single number or a localhost:container port pair."
          (vterm-buffer-name (format "*kubel - vterm - %s@%s*" container pod))
          (vterm-shell "/bin/sh"))
     (vterm)))
+
+;;;###autoload
+(defun kubel-vterm-setup ()
+  "Adds a vterm enty to the KUBEL-EXEC-POP."
+  (require 'vterm)
+  (transient-append-suffix 'kubel-exec-popup "e"
+    '("v" "Vterm" kubel-exec-vterm-pod)))
 
 (defun kubel-exec-ansi-term-pod ()
   "Exec into the pod under the cursor -> `ansi-term'."
@@ -1179,7 +1185,6 @@ RESET is to be called if the search is nil after the first attempt."
    ("!" "Shell command" kubel-exec-pod-by-shell-command)
    ("d" "Dired" kubel-exec-pod)
    ("e" "Eshell" kubel-exec-eshell-pod)
-   ("v" "Vterm" kubel-exec-vterm-pod)
    ("a" "Ansi-term" kubel-exec-ansi-term-pod)
    ("s" "Shell" kubel-exec-shell-pod)])
 

--- a/kubel.el
+++ b/kubel.el
@@ -1006,8 +1006,8 @@ P can be a single number or a localhost:container port pair."
 
 (defun kubel-exec-vterm-pod ()
   "Exec into the pod under the cursor -> vterm."
-  (require 'vterm)
   (interactive)
+  (require 'vterm)
   (kubel-setup-tramp)
   (let* ((dir-prefix (kubel--dir-prefix))
          (con-pod (kubel--get-container-under-cursor))


### PR DESCRIPTION
The PR has two commits, the first one is uncontroversial, the interactive spec should be the first form in the function (with the possible exception of the a declare form iiuc), so we need to swap places with the call to (require 'vterm).

The second commit is something that, although I prefer, I can understand if its rejected. I dislike require forms outside of top-level forms, so I extracted the vterm related function to a separate file. I use vterm myself so I've verified the transient has the option available with the steps in the README.md. Although using vterm from kubel hasn't working for me though but that is out of scope for this PR.

lmkwyt