### PR TITLE
Silence warning about using GOTO-LINE outside of interactive use

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -601,7 +601,8 @@ TYPENAME is the resource type/name."
 (defun kubel--jump-back-to-line ()
   "Jump back to the last cached line number."
   (when kubel--line-number
-    (goto-line kubel--line-number)))
+    (goto-char (point-min))
+    (forward-line (1- kubel--line-number))))
 
 ;; interactive
 (define-minor-mode kubel-yaml-editing-mode


### PR DESCRIPTION
The warning I get when byte-compiling the file is

In kubel--jump-back-to-line:
kubel.el:605:9: Warning: ‘goto-line’ is for interactive use only; use
    ‘forward-line’ instead.

I'm not sure how to check the new code works the same, but I have been used kubel with this patch applied for a week w/o a noticeable issue. A potential bug to look for when reviewing is off-by-one.