### PR TITLE
refactor: Make the line number recorded only when printing the table

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -591,18 +591,6 @@ TYPENAME is the resource type/name."
    (-contains? '("ReplicaSets" "replicasets" "replicasets.apps") kubel-resource)
    (-contains? '("StatefulSets" "statefulsets" "statefulsets.apps") kubel-resource)))
 
-(defun kubel--save-line ()
-  "Save the current line number if the view is unchanged."
-  (if (equal (buffer-name (current-buffer))
-             (kubel--buffer-name))
-      (setq kubel--line-number (+ 1 (count-lines 1 (point))))
-    (setq kubel--line-number nil)))
-
-(defun kubel--jump-back-to-line ()
-  "Jump back to the last cached line number."
-  (when kubel--line-number
-    (goto-line kubel--line-number)))
-
 ;; interactive
 (define-minor-mode kubel-yaml-editing-mode
   "Kubel Yaml editing mode.
@@ -1233,7 +1221,6 @@ DIRECTORY is optional for TRAMP support."
 
 DIRECTORY is optional for TRAMP support."
   (interactive)
-  (kubel--save-line)
   (kubel--pop-to-buffer (kubel--buffer-name))
   (when directory (setq default-directory directory))
   (kubel-mode)
@@ -1253,11 +1240,11 @@ DIRECTORY is optional for TRAMP support."
   (setq tabulated-list-sort-key kubel--list-sort-key)
   (setq tabulated-list-sort-key nil)
   (tabulated-list-init-header)
-  (tabulated-list-print)
+  (let ((line-num (line-number-at-pos (point))))
+    (tabulated-list-print)
+    (goto-line line-num))
   (hl-line-mode 1)
   (run-mode-hooks 'kubel-mode-hook))
-
-(add-hook 'kubel-mode-hook #'kubel--jump-back-to-line)
 
 (provide 'kubel)
 ;;; kubel.el ends here


### PR DESCRIPTION
This avoids the need to save a variable and makes the code more
readable by having the recording and the use of the value at the
same place.