### PR TITLE
Fix completion candidates for KUBEL-SET-CONTEXT

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -190,7 +190,9 @@ CMD is the kubectl command as a list."
 
 CMD is the command string to run."
   (kubel--log-command "kubectl-command" cmd)
-  (shell-command-to-string cmd))
+  (with-output-to-string
+    (with-current-buffer standard-output
+      (shell-command cmd t "*kubel stderr*"))))
 
 (defvar kubel-namespace "default"
   "Current namespace.")

--- a/test/kubel-test.el
+++ b/test/kubel-test.el
@@ -26,7 +26,7 @@
 
 (ert-deftest kubel--test-kubernetes-version ()
   (setq kubel--kubernetes-version-cached nil)
-  (cl-letf (((symbol-function 'shell-command-to-string)
+  (cl-letf (((symbol-function 'kubel--exec-to-string)
              (lambda (cmd) "Client Version: version.Info{Major:\"1\", Minor:\"14\", GitVersion:\"v1.14.10\", GitCommit:\"575467a0eaf3ca1f20eb86215b3bde40a5ae617a\", GitTreeState:\"clean\", BuildDate:\"2019-12-11T12:41:00Z\", GoVersion:\"go1.12.12\", Compiler:\"gc\", Platform:\"darwin/amd64\"}
 Server Version: version.Info{Major:\"1\", Minor:\"12\", GitVersion:\"v1.12.7\", GitCommit:\"6f482974b76db3f1e0f5d24605a9d1d38fad9a2b\", GitTreeState:\"clean\", BuildDate:\"2019-03-25T02:41:57Z\", GoVersion:\"go1.10.8\", Compiler:\"gc\", Platform:\"linux/amd64\"}")))
     (should (equal '(1 14 10) (kubel-kubernetes-version)))))


### PR DESCRIPTION
We can't use SHELL-COMMAND-TO-STRING as calls SHELL-COMMAND with ERROR-BUFFER as
nil. This mixes output from stdout and stderr. This can be an issue as kubectl
will write warnings about the SSO session having expired to standard error, even
when the command can run successfully to w/o an valid session. It still returns a
successful error code.

The specific scenario I run into is when I call KUBEL-SET-CONTEXT w/o a valid
session. The call to retrieve the available contexts expects the shell command
to return a space separated list of contexts. Because stdout and stderr are
combined that list also includes the error message. This results in the call to
completing read to have a lot of nonsense entries, one for each word the error
message has.