### PR TITLE
Add option for propagating environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ Alternatively, you can hit `E` to then select the resource type and the resource
   - auto - default, use `kubectl auth can-i list namespace` to determine if we can list namespaces
   - on - always assume we can list namespaces
   - off - always assume we cannot list namespaces
+- If you want to propagate environment variables, you can use
+  customize on `kubel-env-variables` to propagate it. This is useful
+  for scenarios where you are using something like [envrc](https://github.com/purcell/envrc) to
+  manage multiple clusters:
+
+``` emacs-lisp
+(customize-set-variable 'kubel-env-variables '("KUBECONFIG" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY"))
+```
 
 ## Releases
 

--- a/kubel.el
+++ b/kubel.el
@@ -263,7 +263,7 @@ CMD is the kubectl command as a list."
 
 (defun kubel--env-values ()
   "Utility function to propgate kubernetes related environment variables."
-  (mapcar 'list (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
+  (mapcar (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
 
 (defun kubel--exec-to-string (cmd)
   "Replace \"shell-command-to-string\" to log to process buffer.
@@ -273,7 +273,7 @@ CMD is the command string to run."
   (let ((env-values (kubel--env-values)))
     (with-output-to-string
       (with-current-buffer standard-output
-        (mapcar 'list (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
+        (mapcar (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
         (shell-command cmd t "*kubel stderr*")))))
 
 (defvar kubel-namespace "default"

--- a/kubel.el
+++ b/kubel.el
@@ -263,7 +263,7 @@ CMD is the kubectl command as a list."
 
 (defun kubel--env-values ()
   "Utility function to propgate kubernetes related environment variables."
-  (cl-map 'list (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
+  (mapcar 'list (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
 
 (defun kubel--exec-to-string (cmd)
   "Replace \"shell-command-to-string\" to log to process buffer.
@@ -273,7 +273,7 @@ CMD is the command string to run."
   (let ((env-values (kubel--env-values)))
     (with-output-to-string
       (with-current-buffer standard-output
-        (cl-map 'list (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
+        (mapcar 'list (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
         (shell-command cmd t "*kubel stderr*")))))
 
 (defvar kubel-namespace "default"

--- a/kubel.el
+++ b/kubel.el
@@ -263,7 +263,7 @@ CMD is the kubectl command as a list."
 
 (defun kubel--env-values ()
   "Utility function to propgate kubernetes related environment variables."
-  (map 'list (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
+  (cl-map 'list (lambda(env) `(:name ,env :value ,(getenv env))) kubel-env-variables))
 
 (defun kubel--exec-to-string (cmd)
   "Replace \"shell-command-to-string\" to log to process buffer.

--- a/kubel.el
+++ b/kubel.el
@@ -273,7 +273,7 @@ CMD is the command string to run."
   (let ((env-values (kubel--env-values)))
     (with-output-to-string
       (with-current-buffer standard-output
-        (map 'list (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
+        (cl-map 'list (lambda (env) (setenv (plist-get env ':name) (plist-get env ':value))) env-values)
         (shell-command cmd t "*kubel stderr*")))))
 
 (defvar kubel-namespace "default"


### PR DESCRIPTION
Right now, `kubel` works when the apropriate credential is part of `~/.kube`. But it doesn't work,if I have `KUBECONFIG` environment variable pointing out to somewhere else (basically if it's not globally set). If you use something like `direnv` to have project specific environment variable, kubel doesn't work there. And at work, I usually have separate clusters each being managed in their own directory.

This PR adds supports for propagating environment variables and making kubel working in those environment. For EKS cluster, I have to often propagate some extra environment variables to make it work with `kubel`:

```
(kubel-env-variables (list "KUBECONFIG" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY"))
```