### PR TITLE
Feature: multiple kubel buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We now support managing pretty much any resource!
 - exec into a pod using tramp
 - quick run shell-command
 - scale replicas
+- multiple kubel buffers, each one with different context, namespace, and resource.
 
 ## Installation
 
@@ -74,6 +75,11 @@ To programmatically open a session for a specific context/namespace/resource, ca
 
 ```lisp
 (kubel-open "<context>" "<namespace>" "<OPTIONAL resource>")
+```
+
+Each kubel buffer will automatically be renamed using the following template:
+```
+*kubel session: |<context>|<namespace>|<resource>|*
 ```
 
 ## Shortcuts


### PR DESCRIPTION
Continue on topic https://github.com/abrochard/kubel/issues/96.

After discussing at #112 and base on the idea/code of #57. Thanks to [Diego Alvarez](https://github.com/d1egoaz)



In #57, each time I run `kubel`, it always create a new on buffer with a same buffer name (ya, with a suffix number) and if we want to create multi buffer we have to run multi time of `kubel`, pretty annoy to me.

I resolved these issues by 
- using `(clone-buffer)` to clone the local var and rename later when we switch recourse, namespaces...
- kubel-refresh assume buffer name will match to name of current-buffer, if not it will kill the duplication and rename to correct name

And I added a new interactive function `kubel-switch-to-buffer` to switch to only kubel's buffer by using prefix name

Hi @abrochard, @d1egoaz. Could you guys take a review and test? Thanks

