### PR TITLE
feat: simplified the kubernetes version logic

### DIFF
--- a/test/kubel-test.el
+++ b/test/kubel-test.el
@@ -53,7 +53,7 @@
   }
 }
 ")))
-    (should (equal '(1 27 4) (kubel-kubernetes-version)))))
+    (should (equal '(1 27) (kubel-kubernetes-version)))))
 
 ;; (ert "kubel--test-.*")
 


### PR DESCRIPTION
Instead of relying on string matching we can use `assoc-string` to get the values we need. This means that we lose patch version, but I'm pretty confident that we don't need it.