### PR TITLE
Remove kubectl version check

### DIFF
--- a/test/kubel-test.el
+++ b/test/kubel-test.el
@@ -7,14 +7,6 @@
 (require 'ert)
 (require 'cl-macs)
 
-(ert-deftest kubel--test-kubernetes-compatible-p ()
-  (cl-letf (((symbol-function 'kubel-kubernetes-version)
-             (lambda () '(1 10 9))))
-    (should (kubel-kubernetes-compatible-p '(1 9 0)))
-    (should (kubel-kubernetes-compatible-p '(0 11 0)))
-    (should (not (kubel-kubernetes-compatible-p '(1 11 0))))
-    (should (not (kubel-kubernetes-compatible-p '(2 0 25))))))
-
 (ert-deftest kubel--test-extract-value ()
   (let ((line "0123456789"))
     (should (equal "0" (kubel--extract-value line 0 1)))
@@ -23,37 +15,6 @@
     (should (equal "56789" (kubel--extract-value line 5 "end")))
     (should (equal "-" (kubel--extract-value "     " 0 5)))
     (should (equal "-" (kubel--extract-value "  " 0 "end")))))
-
-(ert-deftest kubel--test-kubernetes-version ()
-  (setq kubel--kubernetes-version-cached nil)
-  (cl-letf (((symbol-function 'kubel--exec-to-string)
-             (lambda (cmd) "{
-  \"clientVersion\": {
-    \"major\": \"1\",
-    \"minor\": \"28\",
-    \"gitVersion\": \"v1.28.1\",
-    \"gitCommit\": \"8dc49c4b984b897d423aab4971090e1879eb4f23\",
-    \"gitTreeState\": \"archive\",
-    \"buildDate\": \"1980-01-01T00:00:00Z\",
-    \"goVersion\": \"go1.20.7\",
-    \"compiler\": \"gc\",
-    \"platform\": \"darwin/arm64\"
-  },
-  \"kustomizeVersion\": \"v5.0.4-0.20230601165947-6ce0bf390ce3\",
-  \"serverVersion\": {
-    \"major\": \"1\",
-    \"minor\": \"27\",
-    \"gitVersion\": \"v1.27.4+k3s1\",
-    \"gitCommit\": \"36645e7311e9bdbbf2adb79ecd8bd68556bc86f6\",
-    \"gitTreeState\": \"clean\",
-    \"buildDate\": \"1970-01-01T01:01:01Z\",
-    \"goVersion\": \"go1.20.7\",
-    \"compiler\": \"gc\",
-    \"platform\": \"linux/amd64\"
-  }
-}
-")))
-    (should (equal '(1 27) (kubel-kubernetes-version)))))
 
 ;; (ert "kubel--test-.*")
 


### PR DESCRIPTION
I noticed a check that verifies if the server version is greater than 1.13. As per the Kubernetes release documentation (https://kubernetes.io/releases/patch-releases/), version 1.13 has reached its end-of-life (EOL) status since 2019. Considering this information, I strongly believe that this check is unnecessary and can be safely removed.

It's only used here:
- https://github.com/abrochard/kubel/blob/a84f09cca8cdc71d55aa78304db4156df46d04e8/kubel.el#L896

Removing this check will not impact the functionality of the codebase, as it is only required for outdated Kubernetes versions that are more than four years old and no longer supported. It is highly unlikely that anyone would be using such an outdated version that cannot be found online for download.

By removing this unnecessary code, we can eliminate technical debt and improve the overall readability and maintainability of the codebase.

Thank you for considering this proposal.