### PR TITLE
change key definition to normal state

### DIFF
--- a/kubel-evil.el
+++ b/kubel-evil.el
@@ -105,9 +105,9 @@
     ("c" "Copy to clipboad..." kubel-copy-popup)
     ("$" "Show Process buffer" kubel-show-process-buffer)]])
 
-(evil-set-initial-state 'kubel-mode 'motion)
+(evil-set-initial-state 'kubel-mode 'normal)
 
-(evil-define-key 'motion kubel-evil-mode-map
+(evil-define-key 'normal kubel-evil-mode-map
   (kbd "RET") #'kubel-get-resource-details
   (kbd "K") #'kubel-set-kubectl-config-file
   (kbd "C") #'kubel-set-context


### PR DESCRIPTION
@ https://github.com/abrochard/kubel/issues/126

Changes the evil keybindings to be under normal state instead of motion

Not sure if safe to merge as maybe people already expect 'motion and could break things