### PR TITLE
Add optional callback arg to kubel--exec function

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -501,6 +501,7 @@ CALLBACK is called when process completes successfully.
 
 PROCESS-NAME is an identifier for the process.  Default to \"kubel-command\".
 ARGS is a ist of arguments.
+CALLBACK is a function that will be executed when the command completes.
 READONLY If true buffer will be in readonly mode(view-mode)."
   (when (equal process-name "")
     (setq process-name "kubel-command"))


### PR DESCRIPTION
Hi,

I've been using this package for a while (thanks for creating it!), and it always bugged me that when I describe resources via RET in the list view, the point always starts at the bottom of the buffer rather than the top. I took a look at the code to see if I could tweak it somehow, and saw that there was actually a `(goto-char (point-min)` call, which suggested that was the intended behaviour. It seemed however that because `make-process` is async, things weren't guaranteed to happen in the correct order.

My lisp skills are not the best just yet and getting this working what somewhat tricky for me, so please feel free to suggest/make changes.