### PR TITLE
Rename kubel-yaml-editing-map to kubel-yaml-editing-mode-map.

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -655,7 +655,7 @@ TYPENAME is the resource type/name."
 	    (yes-or-no-p "Resource modified; kill anyway? "))
     (kill-buffer (current-buffer))))
 
-(defvar kubel-yaml-editing-map
+(defvar kubel-yaml-editing-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'kubel-apply)
     (define-key map (kbd "C-c C-k") #'kubel-kill-buffer)
@@ -669,7 +669,7 @@ TYPENAME is the resource type/name."
 
 Allows simple apply of the changes made.
 
-\\{kubel-yaml-editing-map}")
+\\{kubel-yaml-editing-mode-map}")
 
 (defun kubel-apply ()
   "Save the current buffer to a temp file and try to kubectl apply it."


### PR DESCRIPTION
In order to be picked by define-derived-mode, the map needs to have name composed of the full mode name (including -mode) and -map suffix.  In my testing it worked, because I already defined and eval-ed it before renaming.  Downsides of REPL-based development I guess.

* kubel.el (kubel-yaml-editing-mode-map): Rename from kubel-yaml-editing-map.