### PR TITLE
fix: set stderr to the buffer object (#118)

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -532,7 +532,7 @@ READONLY If true buffer will be in readonly mode(view-mode)."
                   :buffer buffer-name
                   :sentinel (kubel--sentinel callback)
                   :file-handler t
-                  :stderr error-buffer
+                  :stderr (get-buffer-create error-buffer)
                   :command cmd)
     (pop-to-buffer buffer-name)
     (if readonly


### PR DESCRIPTION
When using kubel on TRAMP. I got the issue #118.

After debugging, In tramp-sh-handle-make-process I see stderr can be a buffer object, so we should create it when make-process to avoid tramp issues