### PR TITLE
fix: dir-prefix for TRAMP without explicitly specifically the username.

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -686,7 +686,7 @@ Allows simple apply of the changes made.
   (setq dir-prefix (or
                     (when (tramp-tramp-file-p default-directory)
                       (with-parsed-tramp-file-name default-directory nil
-                        (format "/%s%s:%s@%s:" (or hop "") method user host)))
+                        (format "/%s%s:%s:" (or hop "") method (if user (concat user "@" host) host))))
                     ""))
   (let* ((filename-without-tramp-prefix (format "/tmp/kubel/%s-%s.yaml"
                                                 (replace-regexp-in-string "/" "_"
@@ -969,7 +969,7 @@ P can be a single number or a localhost:container port pair."
   (or
    (when (tramp-tramp-file-p default-directory)
      (with-parsed-tramp-file-name default-directory nil
-       (format "%s%s:%s@%s|" (or hop "") method user host)))
+       (format "%s%s:%s|" (or hop "") method (if user (concat user "@" host) host))))
    ""))
 
 (defun kubel-exec-pod ()


### PR DESCRIPTION
Hi @abrochard,

This patch maintains kubel's compatibility with SSH configurations that define usernames within the `.ssh/config` file, allowing seamless access to remote servers without explicitly specifically the username.