### PR TITLE
fix #143 - reuse only pod vterm buffers

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -1032,7 +1032,7 @@ the variables `kubel-namespace' and `kubel-context', respectively."
          (vterm-buffer-name
           (kubel--shell-buffer-name "vterm" container pod))
          (vterm-shell "/bin/sh"))
-    (vterm)))
+    (vterm nil)))
 
 ;;;###autoload
 (defun kubel-vterm-setup ()


### PR DESCRIPTION
This commit uses the same logic as calling `(vterm)` with a non-numeric prefix argument (e.g. just `C-u M-x vterm`)

The docstring for `(vterm)` says:

> With a nonnumeric prefix arg, create a new session.

So both:
- `(vterm nil)` (like in this commit) 
- `(vterm '(4))` (like you'd call `C-u M-x vterm)` as a user)

behave the same

What the docstring doesn't mention is that if you pass `vterm-buffer-name` AND a non-numeric arg,  the buffer will be created if it doesn't exist, or a buffer with the same name will be reused. This is thanks to `(generate-new-buffer)` using `(get-buffer-create)` underneath here: https://github.com/akermu/emacs-libvterm/blob/f64729ed8b59e46ce827d28222c4087c538de562/vterm.el#L1502

This means that a vterm pod buffer that already exists will be reused if you type "e v" in the pod buffer