### PR TITLE
Use lowercase resource name (like all resources in kubel-set-resource)

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -299,7 +299,7 @@ CMD is the command string to run."
 (defvar-local kubel-namespace "default"
   "Current namespace.")
 
-(defvar-local kubel-resource "Pods"
+(defvar-local kubel-resource "pods"
   "Current resource.")
 
 (defvar-local kubel-context


### PR DESCRIPTION
This is a nitpick - running M-x kubel creates a buffer whose name ends in Pods, but if you press R to run kubel-set-resource and select "pods" again, there will be two buffers - one with uppercase and one with lowercase "pods"

Is this an issue of different cluster implementations having different resource casing? i.e. in some other installation "Pods" is valid while "pods" would be an outlier?

![image](https://github.com/user-attachments/assets/222e07c0-f078-4c44-8c83-1f982e2e13d1)
