### PR TITLE
fix: Don't assume that kubectl will use the namespace default implictely

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -551,7 +551,7 @@ Strip the `*` prefix if the resource is selected"
   (append
    (unless (equal kubel-context "")
      (list "--context" kubel-context))
-   (unless (equal kubel-namespace "default")
+   (unless (equal kubel-namespace "")
      (list "-n" kubel-namespace))))
 
 (defun kubel--get-selector ()


### PR DESCRIPTION
When kubel-namespace is default, the code explicitely avoided providing -n default in the command line. This resulted in kubectl using the value in the kube configuration and falling back to default.

In the former case, having kubel-namespace set to default did use the configured value, leading to a counter intuitive behavior.

I have been playing more and more with namespaces and am used to configure the namespace I am working on using `kubectl config set-context <mycontext> --namespace <somenamespace>`. It feels strange to be brought back to <somenamespace> whenever I explicitely ask kubel to see the "default" one.