### PR TITLE
fix: consider kubel-resource buffers when killing all buffers

### DIFF
--- a/kubel.el
+++ b/kubel.el
@@ -753,7 +753,7 @@ If no parent buffer exists, call `quit-window'."
   "Kill all kubel-related buffers."
   (interactive)
   (dolist (buf (buffer-list))
-    (when (string-prefix-p "*kubel:" (buffer-name buf))
+    (when (string-match-p "^\\*kubel\\(-resource\\)?:" (buffer-name buf))
       (kill-buffer buf))))
 
 (defvar kubel-yaml-editing-mode-map


### PR DESCRIPTION
Before this change, `kubel-kill-all-buffers` would leave behind Kubel buffers describing resources, like:

`*kubel-resource:default:kube-system:get_pods_cilium-48f78_-o_yaml*`

The patch augments the buffer name matching.

Thanks for taking a look.